### PR TITLE
[SX-2190] Fix phpdoc-parser issue #379

### DIFF
--- a/Spryker/Traits/CommentingTrait.php
+++ b/Spryker/Traits/CommentingTrait.php
@@ -21,6 +21,7 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
 
 /**
  * Common functionality around commenting.
@@ -36,14 +37,15 @@ trait CommentingTrait
     protected static function getValueNode(string $tagName, string $tagComment): PhpDocTagValueNode
     {
         static $phpDocParser;
+        $config = new ParserConfig([]);
         if (!$phpDocParser) {
-            $constExprParser = new ConstExprParser();
-            $phpDocParser = new PhpDocParser(new TypeParser($constExprParser), $constExprParser);
+            $constExprParser = new ConstExprParser($config);
+            $phpDocParser = new PhpDocParser($config, new TypeParser($config, $constExprParser), $constExprParser);
         }
 
         static $phpDocLexer;
         if (!$phpDocLexer) {
-            $phpDocLexer = new Lexer();
+            $phpDocLexer = new Lexer($config);
         }
 
         return $phpDocParser->parseTagValue(new TokenIterator($phpDocLexer->tokenize($tagComment)), $tagName);

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     ],
     "require": {
         "php": ">=8.1",
-        "slevomat/coding-standard": "^7.2.0 || ^8.0.1",
+        "slevomat/coding-standard": "^8.4",
         "squizlabs/php_codesniffer": "^3.6.2"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.0.0",
+        "phpstan/phpstan": "^2.0.0",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {


### PR DESCRIPTION
## PR Description
phpdoc-parser added some new constructor parameters, this PR fixes this issue:
CommentingTrait is not working with phpstan/phpdoc-parser >= 1.18.1 #379


